### PR TITLE
Fix start index calculation in AST util

### DIFF
--- a/core/autocomplete/util/ast.ts
+++ b/core/autocomplete/util/ast.ts
@@ -58,7 +58,7 @@ export async function getScopeAroundRange(
   const lines = range.contents.split("\n");
   const startIndex =
     lines.slice(0, s.line).join("\n").length +
-    (lines[s.line]?.slice(s.character).length ?? 0);
+    (lines[s.line]?.slice(0, s.character).length ?? 0);
   const endIndex =
     lines.slice(0, e.line).join("\n").length +
     (lines[e.line]?.slice(0, e.character).length ?? 0);


### PR DESCRIPTION
## Summary
- fix `getScopeAroundRange` startIndex bug


------
https://chatgpt.com/codex/tasks/task_e_6845f362256c832184e62779d0b9dc7a